### PR TITLE
Remove desktop ui property on artyfx plugins

### DIFF
--- a/plugins-fixed/artyfx.lv2/bitta.ttl
+++ b/plugins-fixed/artyfx.lv2/bitta.ttl
@@ -48,8 +48,6 @@
 
   lv2:optionalFeature lv2:hardRTCapable ;
 
-  ui:ui <http://www.openavproductions.com/artyfx#bitta/gui>;
-
   lv2:requiredFeature <http://lv2plug.in/ns/ext/urid#map> ;
 
   lv2:port [

--- a/plugins-fixed/artyfx.lv2/della.ttl
+++ b/plugins-fixed/artyfx.lv2/della.ttl
@@ -48,10 +48,6 @@
   doap:license <http://usefulinc.com/doap/licenses/gpl> ;
   lv2:project <http://www.openavproductions.com/artyfx> ;
 
-
-
-  ui:ui <http://www.openavproductions.com/artyfx#della/gui>;
-
   lv2:requiredFeature <http://lv2plug.in/ns/ext/urid#map> ;
 
   lv2:port [

--- a/plugins-fixed/artyfx.lv2/ducka.ttl
+++ b/plugins-fixed/artyfx.lv2/ducka.ttl
@@ -44,10 +44,6 @@
   doap:license <http://usefulinc.com/doap/licenses/gpl> ;
   lv2:project <http://www.openavproductions.com/artyfx> ;
 
-
-
-  ui:ui <http://www.openavproductions.com/artyfx#ducka/gui>;
-
   lv2:port [
     a lv2:AudioPort ,
       lv2:InputPort ;

--- a/plugins-fixed/artyfx.lv2/filta.ttl
+++ b/plugins-fixed/artyfx.lv2/filta.ttl
@@ -50,8 +50,6 @@ Modeled by OpenAV
 
   lv2:optionalFeature lv2:hardRTCapable;
 
-  ui:ui <http://www.openavproductions.com/artyfx#filta/gui>;
-
   lv2:port [
     a lv2:AudioPort ,
       lv2:InputPort ;

--- a/plugins-fixed/artyfx.lv2/kuiza.ttl
+++ b/plugins-fixed/artyfx.lv2/kuiza.ttl
@@ -50,8 +50,6 @@ Modeled by openAV
   doap:license <http://usefulinc.com/doap/licenses/gpl> ;
   lv2:project <http://www.openavproductions.com/artyfx> ;
 
-  ui:ui <http://www.openavproductions.com/artyfx#kuiza/gui>;
-
   lv2:requiredFeature <http://lv2plug.in/ns/ext/urid#map> ;
 
   lv2:port [

--- a/plugins-fixed/artyfx.lv2/masha.ttl
+++ b/plugins-fixed/artyfx.lv2/masha.ttl
@@ -45,8 +45,6 @@
   lv2:project <http://www.openavproductions.com/artyfx> ;
 
 
-  ui:ui <http://www.openavproductions.com/artyfx#masha/gui>;
-
   lv2:port [
     a lv2:AudioPort ,
       lv2:InputPort ;

--- a/plugins-fixed/artyfx.lv2/modguis.ttl
+++ b/plugins-fixed/artyfx.lv2/modguis.ttl
@@ -66,36 +66,6 @@
 ###############################################################################
 
 ###############################################################################
-## START http://www.openavproductions.com/artyfx#driva
-
-<http://www.openavproductions.com/artyfx#driva>
-    modgui:gui [
-        modgui:resourcesDirectory <modgui> ;
-        modgui:iconTemplate <modgui/icon-driva.html> ;
-        modgui:stylesheet <modgui/stylesheet-driva.css> ;
-        modgui:screenshot <modgui/screenshot-driva.png> ;
-        modgui:thumbnail <modgui/thumbnail-driva.png> ;
-        modgui:brand "OpenAV" ;
-        modgui:label "Driva" ;
-        modgui:model "japanese" ;
-        modgui:panel "4-knobs" ;
-        modgui:color "darkblue" ;
-        modgui:knob "orange" ;
-        modgui:port [
-            lv2:index 0 ;
-            lv2:symbol "tone" ;
-            lv2:name "Tone" ;
-        ] , [
-            lv2:index 1 ;
-            lv2:symbol "distortion" ;
-            lv2:name "Distortion" ;
-        ] ;
-    ] .
-    
-## END http://www.openavproductions.com/artyfx#driva
-###############################################################################
-
-###############################################################################
 ## START http://www.openavproductions.com/artyfx#ducka
 
 <http://www.openavproductions.com/artyfx#ducka>

--- a/plugins-fixed/artyfx.lv2/panda.ttl
+++ b/plugins-fixed/artyfx.lv2/panda.ttl
@@ -45,9 +45,6 @@
   doap:license <http://usefulinc.com/doap/licenses/gpl> ;
   lv2:project <http://www.openavproductions.com/artyfx> ;
 
-
-  ui:ui <http://www.openavproductions.com/artyfx#panda/gui>;
-
   lv2:requiredFeature <http://lv2plug.in/ns/ext/urid#map> ;
 
   lv2:port [

--- a/plugins/abGate.lv2/gate.ttl
+++ b/plugins/abGate.lv2/gate.ttl
@@ -1,7 +1,7 @@
 @prefix lv2:  <http://lv2plug.in/ns/lv2core#>.
 @prefix doap: <http://usefulinc.com/ns/doap#>.
 @prefix ui: <http://lv2plug.in/ns/extensions/ui#>.
-@prefix units: <http://lv2plug.in/ns/extension/units#>.
+@prefix units: <http://lv2plug.in/ns/extensions/units#>.
 @prefix pprops: <http://lv2plug.in/ns/ext/port-props#>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -12,7 +12,6 @@
 	lv2:binary <gate.so>;
 
 	doap:name "abGate";
-	doap:creator "Antanas Bruzas";
 
 	doap:developer [
 		foaf:name "Antanas Bruzas";


### PR DESCRIPTION
Fixes validation since these UIs are never defined.
We dont use them, so this is better anyway.
