### PR TITLE
fixed incorrect parameter mappings

### DIFF
--- a/plugins-fixed/mod-mda-BeatBox.lv2/BeatBox.ttl
+++ b/plugins-fixed/mod-mda-BeatBox.lv2/BeatBox.ttl
@@ -44,6 +44,7 @@ To record your own sounds, use the Record control to monitor the plug's input, t
         lv2:index 1 ;
         lv2:name "Hat Rate" ;
         lv2:symbol "hat_rate" ;
+        lv2:portProperty epp:logarithmic;
         lv2:default 130.0 ;
         lv2:minimum 40.0 ;
         lv2:maximum 240.0 ;
@@ -55,8 +56,8 @@ To record your own sounds, use the Record control to monitor the plug's input, t
         lv2:index 2 ;
         lv2:name "Hat Mix" ;
         lv2:symbol "hat_mix" ;
-        lv2:default -34.0 ;
-        lv2:minimum -80.0 ;
+        lv2:default 0.0 ;
+        lv2:minimum -24.0 ;
         lv2:maximum 12.0 ;
         units:unit units:db ;
         rdfs:comment "Sample playback level"
@@ -89,9 +90,9 @@ To record your own sounds, use the Record control to monitor the plug's input, t
         lv2:index 5 ;
         lv2:name "Kik Mix" ;
         lv2:symbol "kik_mix" ;
-        lv2:default -34.0 ;
-        lv2:minimum -80.0 ;
-        lv2:maximum 1.02 ;
+        lv2:default 0.0 ;
+        lv2:minimum -24.0 ;
+        lv2:maximum 12.0 ;
         units:unit units:db
     ] , [
         a lv2:InputPort ,
@@ -121,8 +122,8 @@ To record your own sounds, use the Record control to monitor the plug's input, t
         lv2:index 8 ;
         lv2:name "Snr Mix" ;
         lv2:symbol "snr_mix" ;
-        lv2:default -34.0 ;
-        lv2:minimum -80.0 ;
+        lv2:default 0.0 ;
+        lv2:minimum -24.0 ;
         lv2:maximum 12.0 ;
         units:unit units:db
     ] , [
@@ -168,13 +169,14 @@ To record your own sounds, use the Record control to monitor the plug's input, t
         lv2:index 11 ;
         lv2:name "Thru Mix" ;
         lv2:symbol "thru_mix" ;
-        lv2:default -41.0 ;
-        lv2:minimum -41.0 ;
-        lv2:maximum 0.0 ;
+        #lv2:portProperty epp:logarithmic ;
+        lv2:default -45.0 ;
+        lv2:minimum -45.0 ;
+        lv2:maximum 0.0 ; # change back to -0.0001 w/ scalePoint if log works
         lv2:scalePoint [
             rdfs:label "OFF" ;
-            rdf:value -41.0
-        ];
+            rdf:value -45.0
+        ]
         units:unit units:db ;
         rdfs:comment "Allow some of the input signal to be mixed with the output"
     ] , [

--- a/plugins-fixed/mod-mda-DX10.lv2/DX10.ttl
+++ b/plugins-fixed/mod-mda-DX10.lv2/DX10.ttl
@@ -11,23 +11,6 @@
 @prefix units: <http://lv2plug.in/ns/extensions/units#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
-#mda:
-#    a doap:Project ;
-#    lv2:symbol "mda" ;
-#    doap:name "MDA LV2" ;
-#    doap:shortdesc "An LV2 port of the MDA plugins." ;
-#    doap:homepage <http://drobilla.net/software/mda-lv2> ;
-#    doap:maintainer [
-#        foaf:name "MOD Team";
-#        foaf:homepage <http://moddevices.com>;
-#        foaf:mbox <mailto:devel@moddevices.com>;
-#    ] ;
-#    doap:developer [
-#        a foaf:Person ;
-#        foaf:name "Paul Kellett" ;
-#        foaf:mbox <mailto:paul@mda-vst.com>
-#    ] .
-
 mda:mainIn
     a pg:StereoGroup ,
         pg:InputGroup ;
@@ -64,6 +47,7 @@ The DX10 is inspired by the later Yamaha DX© (*) synthesizers which are some of
 
 Features:
 Modeled by MDA
+N.B. The carrier operator has a fixed coarse tuning ratio of 2. 
 (*) “Other product names modeled in the software trademarks of their respective companies that do not endorse and are not associated or affiliated with MOD. Yamaha DX© is a trademark or trade name of another manufacturer and was used merely to identify the product whose sound was reviewed in the creation of the product. All other trademarks are the property of their respective holders.”
     """ ;
     lv2:minorVersion 0;

--- a/plugins-fixed/mod-mda-DX10.lv2/DX10.ttl
+++ b/plugins-fixed/mod-mda-DX10.lv2/DX10.ttl
@@ -77,10 +77,11 @@ Modeled by MDA
         lv2:index 0 ;
         lv2:name "Attack" ;
         lv2:symbol "attack" ;
-        lv2:default 0.0 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 100.0 ;
-        units:unit units:pc;
+        lv2:default 10.0 ;
+        lv2:minimum 2.5 ;
+        lv2:maximum 4000.0 ;
+        units:unit units:ms;
+        lv2:portProperty epp:logarithmic;
         lv2:designation param:attack ;
         pg:group <http://moddevices.com/plugins/mda/DX10/env>
     ] , [
@@ -89,22 +90,28 @@ Modeled by MDA
         lv2:index 1 ;
         lv2:name "Decay" ;
         lv2:symbol "decay" ;
-        lv2:default 65.0 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 100.0 ;
-        units:unit units:pc;
+        lv2:default 250.0 ;
+        lv2:minimum 46.5 ;
+        lv2:maximum 7000.0 ;
+        units:unit units:ms;
+        lv2:portProperty epp:logarithmic;
         lv2:designation param:decay ;
         pg:group <http://moddevices.com/plugins/mda/DX10/env>
+        lv2:scalePoint [
+            rdfs:label "Inf" ;
+            rdf:value 7000.0
+        ]
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;
         lv2:index 2 ;
         lv2:name "Release" ;
         lv2:symbol "release" ;
-        lv2:default 44.1 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 100.0 ;
-        units:unit units:pc;
+        lv2:default 350.0 ;
+        lv2:minimum 46.5 ;
+        lv2:maximum 7000.0 ;
+        units:unit units:ms;
+        lv2:portProperty epp:logarithmic;
         lv2:designation param:release ;
         pg:group <http://moddevices.com/plugins/mda/DX10/env>
     ] , [
@@ -113,9 +120,9 @@ Modeled by MDA
         lv2:index 3 ;
         lv2:name "Coarse" ;
         lv2:symbol "coarse" ;
-        lv2:portProperty epp:logarithmic;
-        lv2:default 33.68 ;
-        lv2:minimum 0.01 ;
+        lv2:portProperty lv2:integer;
+        lv2:default 2.0 ;
+        lv2:minimum 0.0 ;
         lv2:maximum 40.0 ;
         units:unit [
             rdfs:label   "ratio" ;
@@ -153,10 +160,11 @@ Modeled by MDA
         lv2:index 6 ;
         lv2:name "Mod Dec" ;
         lv2:symbol "mod_dec" ;
-        lv2:default 80.0 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 100.0 ;
-        units:unit units:pc
+        lv2:default 250.0 ;
+        lv2:minimum 17.0 ;
+        lv2:maximum 7000.0 ;
+        units:unit units:ms;
+        lv2:portProperty epp:logarithmic;
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;
@@ -173,10 +181,15 @@ Modeled by MDA
         lv2:index 8 ;
         lv2:name "Mod Rel" ;
         lv2:symbol "mod_rel" ;
-        lv2:default 80.0 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 100.0 ;
-        units:unit units:pc
+        lv2:default 350.0 ;
+        lv2:minimum 46.5 ;
+        lv2:maximum 7000.0 ;
+        units:unit units:ms;
+        lv2:portProperty epp:logarithmic;
+        lv2:scalePoint [
+            rdfs:label "Inf" ;
+            rdf:value 7000.0
+        ]
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;

--- a/plugins-fixed/mod-mda-DX10.lv2/default-preset.ttl
+++ b/plugins-fixed/mod-mda-DX10.lv2/default-preset.ttl
@@ -7,13 +7,13 @@
 	lv2:appliesTo <http://moddevices.com/plugins/mda/DX10> ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0.0
+		pset:value 2.5
 	] , [
 		lv2:symbol "coarse" ;
-		pset:value 33.68000031
+		pset:value 28.36
 	] , [
 		lv2:symbol "decay" ;
-		pset:value 65.0
+		pset:value 6123.89
 	] , [
 		lv2:symbol "fine" ;
 		pset:value 0.24699999
@@ -25,13 +25,13 @@
 		pset:value 10.35000038
 	] , [
 		lv2:symbol "mod_dec" ;
-		pset:value 80.0
+		pset:value 4599.18
 	] , [
 		lv2:symbol "mod_init" ;
 		pset:value 23.0
 	] , [
 		lv2:symbol "mod_rel" ;
-		pset:value 80.0
+		pset:value 6485.07
 	] , [
 		lv2:symbol "mod_sus" ;
 		pset:value 5.0
@@ -46,7 +46,7 @@
 		pset:value 0.0
 	] , [
 		lv2:symbol "release" ;
-		pset:value 44.09999847
+		pset:value 424.42
 	] , [
 		lv2:symbol "vibrato" ;
 		pset:value 0.0
@@ -54,4 +54,3 @@
 		lv2:symbol "waveform" ;
 		pset:value 44.70000076
 	] .
-

--- a/plugins-fixed/mod-mda-DX10.lv2/presets.ttl
+++ b/plugins-fixed/mod-mda-DX10.lv2/presets.ttl
@@ -8,19 +8,19 @@
 	rdfs:label "Bright E.Piano" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 65 ;
+		pset:value 6123.89 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 44.1 ;
+		pset:value 424.42 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 33.68 ;
+		pset:value 28.36 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -32,7 +32,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 80 ;
+		pset:value 4599.18 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -40,7 +40,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 80 ;
+		pset:value 6485.07 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -77,19 +77,19 @@
 	rdfs:label "Jazz E.Piano" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 50 ;
+		pset:value 2567.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 10 ;
+		pset:value 76.77 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 26.84 ;
+		pset:value 18.01 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -101,7 +101,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 33.6 ;
+		pset:value 178.64 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -109,7 +109,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 80 ;
+		pset:value 6485.07 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -146,19 +146,19 @@
 	rdfs:label "E.Piano Pad" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 70 ;
+		pset:value 6241.99 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 40 ;
+		pset:value 345.55 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 9.2 ;
+		pset:value 2.12 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -170,7 +170,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 47.4 ;
+		pset:value 469.4 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -178,7 +178,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 80 ;
+		pset:value 6485.07 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -215,19 +215,19 @@
 	rdfs:label "Fuzzy E.Piano" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 70 ;
+		pset:value 6241.99 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 40 ;
+		pset:value 345.55 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 12.8 ;
+		pset:value 4.1 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -239,7 +239,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 67 ;
+		pset:value 1851.16 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -247,7 +247,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 80 ;
+		pset:value 6485.07 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -284,19 +284,19 @@
 	rdfs:label "Soft Chimes" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 40 ;
+		pset:value 47.82 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 60 ;
+		pset:value 5727.86 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 65 ;
+		pset:value 1210.38 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 30.4 ;
+		pset:value 23.1 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -308,7 +308,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 25 ;
+		pset:value 97.84 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -316,7 +316,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 90 ;
+		pset:value 6737.62 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -353,19 +353,19 @@
 	rdfs:label "Harpsichord" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 34.2 ;
+		pset:value 722.87 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 0 ;
+		pset:value 46.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 11.2 ;
+		pset:value 3.14 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -377,7 +377,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 10 ;
+		pset:value 34.24 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -385,7 +385,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 74 ;
+		pset:value 6338.11 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -422,19 +422,19 @@
 	rdfs:label "Funk Clav" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 40 ;
+		pset:value 1151.19 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 10 ;
+		pset:value 76.77 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 14.4 ;
+		pset:value 5.18 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -446,7 +446,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 16 ;
+		pset:value 52.11 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -454,7 +454,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 80 ;
+		pset:value 6485.07 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -491,19 +491,19 @@
 	rdfs:label "Sitar" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 50 ;
+		pset:value 2567.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 70.4 ;
+		pset:value 1586.77 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 9.2 ;
+		pset:value 2.12 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -515,7 +515,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 75 ;
+		pset:value 3240.9 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -523,7 +523,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 77 ;
+		pset:value 6411.17 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -560,19 +560,19 @@
 	rdfs:label "Chiff Organ" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 60 ;
+		pset:value 209.13 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 99 ;
+		pset:value 6973.31 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 40 ;
+		pset:value 345.55 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 12.8 ;
+		pset:value 4.1 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -584,7 +584,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 30 ;
+		pset:value 138.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -592,7 +592,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 24 ;
+		pset:value 318.91 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -629,19 +629,19 @@
 	rdfs:label "Tinkle" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 50 ;
+		pset:value 2567.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 65 ;
+		pset:value 1210.38 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 14.72 ;
+		pset:value 5.42 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -653,7 +653,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 55 ;
+		pset:value 799.11 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -661,7 +661,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 90 ;
+		pset:value 6737.62 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -698,19 +698,19 @@
 	rdfs:label "Space Pad" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 70 ;
+		pset:value 6241.99 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 52 ;
+		pset:value 630.71 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 9.2 ;
+		pset:value 2.12 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -722,7 +722,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 72 ;
+		pset:value 2626.98 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -730,7 +730,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 73 ;
+		pset:value 6313.94 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -767,19 +767,19 @@
 	rdfs:label "Koto" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 24 ;
+		pset:value 318.91 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 0 ;
+		pset:value 46.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 15.6 ;
+		pset:value 6.08 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -791,7 +791,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 10 ;
+		pset:value 34.24 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -799,7 +799,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 74 ;
+		pset:value 6338.11 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -836,19 +836,19 @@
 	rdfs:label "Harp" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 50 ;
+		pset:value 2567.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 70 ;
+		pset:value 1555.27 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 6.4 ;
+		pset:value 1.02 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -860,7 +860,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 34.9 ;
+		pset:value 195.66 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -868,7 +868,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 28 ;
+		pset:value 439.58 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -905,19 +905,19 @@
 	rdfs:label "Jazz Guitar" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 50 ;
+		pset:value 2567.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 10 ;
+		pset:value 76.77 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 15.6 ;
+		pset:value 6.08 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -929,7 +929,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 25 ;
+		pset:value 97.84 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -937,7 +937,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 80 ;
+		pset:value 6485.07 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -974,19 +974,19 @@
 	rdfs:label "Steel Drum" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 30 ;
+		pset:value 516.09 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 50.7 ;
+		pset:value 590.91 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 19.2 ;
+		pset:value 9.22 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -998,7 +998,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 10 ;
+		pset:value 34.24 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1006,7 +1006,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 73 ;
+		pset:value 6313.94 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1043,19 +1043,19 @@
 	rdfs:label "Log Drum" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 30 ;
+		pset:value 516.09 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 50 ;
+		pset:value 570.53 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 12.8 ;
+		pset:value 4.1 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1067,7 +1067,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 7.9 ;
+		pset:value 29.56 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1075,7 +1075,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 50 ;
+		pset:value 2567.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1112,19 +1112,19 @@
 	rdfs:label "Trumpet" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 99 ;
+		pset:value 6973.31 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 10 ;
+		pset:value 76.77 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 9.2 ;
+		pset:value 2.12 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1136,7 +1136,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 20 ;
+		pset:value 68.95 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1144,7 +1144,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 80 ;
+		pset:value 6485.07 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1181,19 +1181,19 @@
 	rdfs:label "Horn" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 28 ;
+		pset:value 19.73 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 99 ;
+		pset:value 6973.31 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 28 ;
+		pset:value 189.32 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 9.2 ;
+		pset:value 2.12 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1205,7 +1205,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 40 ;
+		pset:value 279.62 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1213,7 +1213,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 80 ;
+		pset:value 6485.07 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1250,19 +1250,19 @@
 	rdfs:label "Reed 1" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 22 ;
+		pset:value 12.67 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 99 ;
+		pset:value 6973.31 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 25 ;
+		pset:value 162.88 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 6.8 ;
+		pset:value 1.16 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1274,7 +1274,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 31 ;
+		pset:value 148.92 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1282,7 +1282,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 90 ;
+		pset:value 6737.62 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1319,19 +1319,19 @@
 	rdfs:label "Reed 2" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 22 ;
+		pset:value 12.67 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 99 ;
+		pset:value 6973.31 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 25 ;
+		pset:value 162.88 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 18 ;
+		pset:value 8.1 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1343,7 +1343,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 31 ;
+		pset:value 148.92 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1351,7 +1351,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 90 ;
+		pset:value 6737.62 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1388,19 +1388,19 @@
 	rdfs:label "Violin" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 69.7 ;
+		pset:value 427.77 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 99 ;
+		pset:value 6973.31 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 42.1 ;
+		pset:value 383.92 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 9.2 ;
+		pset:value 2.12 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1412,7 +1412,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 39 ;
+		pset:value 260.71 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1420,7 +1420,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 80 ;
+		pset:value 6485.07 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1457,19 +1457,19 @@
 	rdfs:label "Chunky Bass" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 40 ;
+		pset:value 1151.19 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 0 ;
+		pset:value 46.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 11.2 ;
+		pset:value 3.14 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1481,7 +1481,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 25 ;
+		pset:value 97.84 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1489,7 +1489,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 50 ;
+		pset:value 2567.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1526,19 +1526,19 @@
 	rdfs:label "E.Bass" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 23 ;
+		pset:value 13.64 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 50 ;
+		pset:value 2567.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 10 ;
+		pset:value 76.77 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 15.8 ;
+		pset:value 6.24 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1550,7 +1550,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 9.2 ;
+		pset:value 32.37 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1558,7 +1558,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 15 ;
+		pset:value 154.91 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1595,19 +1595,19 @@
 	rdfs:label "Clunk Bass" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 60 ;
+		pset:value 5727.86 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 40 ;
+		pset:value 345.55 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 9.2 ;
+		pset:value 2.12 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1619,7 +1619,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 32 ;
+		pset:value 159.71 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1627,7 +1627,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 90 ;
+		pset:value 6737.62 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1664,19 +1664,19 @@
 	rdfs:label "Thick Bass" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 60 ;
+		pset:value 5727.86 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 40 ;
+		pset:value 345.55 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 6.8 ;
+		pset:value 1.16 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1688,7 +1688,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 35 ;
+		pset:value 197.04 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1696,7 +1696,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 90 ;
+		pset:value 6737.62 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1733,19 +1733,19 @@
 	rdfs:label "Sine Bass" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 60 ;
+		pset:value 5727.86 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 49 ;
+		pset:value 542.62 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 6.8 ;
+		pset:value 1.16 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1757,7 +1757,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 40 ;
+		pset:value 279.62 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1765,7 +1765,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 90 ;
+		pset:value 6737.62 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1802,19 +1802,19 @@
 	rdfs:label "Square Bass" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 60 ;
+		pset:value 5727.86 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 10 ;
+		pset:value 76.77 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 12.8 ;
+		pset:value 4.1 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1826,7 +1826,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 67 ;
+		pset:value 1851.16 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1834,7 +1834,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 15 ;
+		pset:value 154.91 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1871,19 +1871,19 @@
 	rdfs:label "Upright Bass 1" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 30 ;
+		pset:value 22.87 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 50 ;
+		pset:value 2567.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 40 ;
+		pset:value 345.55 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 11.2 ;
+		pset:value 3.14 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1895,7 +1895,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 54 ;
+		pset:value 745.08 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1903,7 +1903,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 70 ;
+		pset:value 6241.99 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -1940,19 +1940,19 @@
 	rdfs:label "Upright Bass 2" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 30 ;
+		pset:value 22.87 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 50 ;
+		pset:value 2567.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 40 ;
+		pset:value 345.55 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 14.4 ;
+		pset:value 5.18 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -1964,7 +1964,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 7 ;
+		pset:value 27.75 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -1972,7 +1972,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 70 ;
+		pset:value 6241.99 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -2009,19 +2009,19 @@
 	rdfs:label "Harmonics" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 50 ;
+		pset:value 2567.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 50 ;
+		pset:value 570.53 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 11.2 ;
+		pset:value 3.14 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -2033,7 +2033,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 20 ;
+		pset:value 68.95 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -2041,7 +2041,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 70 ;
+		pset:value 6241.99 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -2078,19 +2078,19 @@
 	rdfs:label "Scratch" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 50 ;
+		pset:value 2567.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 0 ;
+		pset:value 46.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 0 ;
+		pset:value 0.0 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -2102,7 +2102,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 63 ;
+		pset:value 1399.04 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -2110,7 +2110,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 0 ;
+		pset:value 46.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -2147,19 +2147,19 @@
 	rdfs:label "Syn Tom" ;
 	lv2:port [
 		lv2:symbol "attack" ;
-		pset:value 0 ;
+		pset:value 2.5 ;
 	] ;
 	lv2:port [
 		lv2:symbol "decay" ;
-		pset:value 35.5 ;
+		pset:value 802.33 ;
 	] ;
 	lv2:port [
 		lv2:symbol "release" ;
-		pset:value 35 ;
+		pset:value 268.92 ;
 	] ;
 	lv2:port [
 		lv2:symbol "coarse" ;
-		pset:value 0 ;
+		pset:value 0.0 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine" ;
@@ -2171,7 +2171,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_dec" ;
-		pset:value 0 ;
+		pset:value 17.0 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_sus" ;
@@ -2179,7 +2179,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "mod_rel" ;
-		pset:value 50 ;
+		pset:value 2567.85 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mod_vel" ;
@@ -2209,4 +2209,3 @@
 		lv2:symbol "lfo_rate" ;
 		pset:value 6.5 ;
 	] .
-

--- a/plugins-fixed/mod-mda-Detune.lv2/Detune.ttl
+++ b/plugins-fixed/mod-mda-Detune.lv2/Detune.ttl
@@ -20,8 +20,8 @@ mda:Detune
     pg:mainInput mda:mainIn ;
     pg:mainOutput mda:mainOut ;
     rdfs:comment """
-The Detune is a low-quality stereo pitch shifter. It can be used for the sort of detune effects found on multi-effects. It will create a widening effect but wont ‘swoosh’ like a chorus. 
-This effect was very popular in the 80’s with bands such as Boston and Judas Priest, but Ozzy Osbourne is also known for using detuning on his vocals. 
+The Detune is a low-quality stereo pitch shifter. It can be used for the sort of detune effects found on multi-effects. It will create a widening effect but wont ‘swoosh’ like a chorus.
+This effect was very popular in the 80’s with bands such as Boston and Judas Priest, but Ozzy Osbourne is also known for using detuning on his vocals.
 
 Features:
 Modeled by MDA
@@ -37,9 +37,10 @@ Modeled by MDA
         lv2:index 0 ;
         lv2:name "Detune" ;
         lv2:symbol "detune" ;
-        lv2:default 120.0 ;
+        lv2:default 2.4 ;
         lv2:minimum 0.0 ;
         lv2:maximum 300.0 ;
+        lv2:portProperty epp:logarithmic ;
         units:unit units:cent ;
         rdfs:comment "Detune amount in cents (left channel is lowered in pitch, right channel is raised)"
     ] , [

--- a/plugins-fixed/mod-mda-Detune.lv2/default-preset.ttl
+++ b/plugins-fixed/mod-mda-Detune.lv2/default-preset.ttl
@@ -7,7 +7,7 @@
 	lv2:appliesTo <http://moddevices.com/plugins/mda/Detune> ;
 	lv2:port [
 		lv2:symbol "detune" ;
-		pset:value 120.0
+		pset:value 19.2
 	] , [
 		lv2:symbol "latency" ;
 		pset:value 92.90000153
@@ -18,4 +18,3 @@
 		lv2:symbol "output" ;
 		pset:value 0.0
 	] .
-

--- a/plugins-fixed/mod-mda-Detune.lv2/presets.ttl
+++ b/plugins-fixed/mod-mda-Detune.lv2/presets.ttl
@@ -2,27 +2,6 @@
 @prefix pset: <http://lv2plug.in/ns/ext/presets#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://moddevices.com/plugins/mda/presets#Detune-stereo-detune>
-	a pset:Preset ;
-	lv2:appliesTo <http://moddevices.com/plugins/mda/Detune> ;
-	rdfs:label "Stereo Detune" ;
-	lv2:port [
-		lv2:symbol "detune" ;
-		pset:value 2.4 ;
-	] ;
-	lv2:port [
-		lv2:symbol "mix" ;
-		pset:value 89.1 ;
-	] ;
-	lv2:port [
-		lv2:symbol "output" ;
-		pset:value 0 ;
-	] ;
-	lv2:port [
-		lv2:symbol "latency" ;
-		pset:value 49.35 ;
-	] .
-
 <http://moddevices.com/plugins/mda/presets#Detune-symphonic>
 	a pset:Preset ;
 	lv2:appliesTo <http://moddevices.com/plugins/mda/Detune> ;

--- a/plugins-fixed/mod-mda-Detune.lv2/presets.ttl
+++ b/plugins-fixed/mod-mda-Detune.lv2/presets.ttl
@@ -8,7 +8,7 @@
 	rdfs:label "Stereo Detune" ;
 	lv2:port [
 		lv2:symbol "detune" ;
-		pset:value 60 ;
+		pset:value 2.4 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mix" ;
@@ -29,7 +29,7 @@
 	rdfs:label "Symphonic" ;
 	lv2:port [
 		lv2:symbol "detune" ;
-		pset:value 60 ;
+		pset:value 2.4 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mix" ;
@@ -50,7 +50,7 @@
 	rdfs:label "Out Of Tune" ;
 	lv2:port [
 		lv2:symbol "detune" ;
-		pset:value 240 ;
+		pset:value 153.6 ;
 	] ;
 	lv2:port [
 		lv2:symbol "mix" ;
@@ -64,4 +64,3 @@
 		lv2:symbol "latency" ;
 		pset:value 49.35 ;
 	] .
-

--- a/plugins-fixed/mod-mda-DubDelay.lv2/DubDelay.ttl
+++ b/plugins-fixed/mod-mda-DubDelay.lv2/DubDelay.ttl
@@ -10,23 +10,6 @@
 @prefix epp: <http://lv2plug.in/ns/ext/port-props#>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
-#mda:
-#    a doap:Project ;
-#    lv2:symbol "mda" ;
-#    doap:name "MDA LV2" ;
-#    doap:shortdesc "An LV2 port of the MDA plugins." ;
-#    doap:homepage <http://drobilla.net/software/mda-lv2> ;
-#    doap:maintainer [
-#        foaf:name "MOD Team";
-#        foaf:homepage <http://moddevices.com>;
-#        foaf:mbox <mailto:devel@moddevices.com>;
-#    ] ;
-#    doap:developer [
-#        a foaf:Person ;
-#        foaf:name "Paul Kellett" ;
-#        foaf:mbox <mailto:paul@mda-vst.com>
-#    ] .
-
 mda:mainIn
     a pg:StereoGroup ,
         pg:InputGroup ;
@@ -39,8 +22,6 @@ mda:mainOut
     pg:source mda:mainIn ;
     lv2:name "Output" ;
     lv2:symbol "out" .
-
-
 
 mda:DubDelay
     a lv2:Plugin ,
@@ -73,10 +54,10 @@ Modeled by MDA
         lv2:name "Delay" ;
         lv2:shortName "Time" ;
         lv2:symbol "delay" ;
-        lv2:default 1835.25 ;
+        lv2:default 460 ;
         lv2:minimum 0.0 ;
-        lv2:maximum 7341.0 ;
-        
+        lv2:maximum 7500.0 ;
+        lv2:portProperty epp:logarithmic ;
         units:unit units:ms ;
         lv2:portProperty  mod:tapTempo , mod:tempoRelatedDynamicScalePoints;
         rdfs:comment "Delay time (delay is mono for authenticity!)"
@@ -114,7 +95,7 @@ Modeled by MDA
         lv2:name "LFO Depth" ;
         lv2:shortName "Depth" ;
         lv2:symbol "lfo_depth" ;
-        lv2:default 50.0 ;
+        lv2:default 30.0 ;
         lv2:minimum 0.0 ;
         lv2:maximum 100.0 ;
         units:unit units:pc;
@@ -152,12 +133,12 @@ Modeled by MDA
         lv2:shortName "Level" ;
         lv2:symbol "output" ;
         lv2:default 0.0 ;
-        lv2:minimum -34.0 ;
+        lv2:minimum -12.0 ;
         lv2:maximum 6.0 ;
-        lv2:scalePoint [
-            rdfs:label "OFF" ;
-            rdf:value -34.0
-        ];
+        #lv2:scalePoint [
+        #    rdfs:label "OFF" ;
+        #    rdf:value -34.0
+        #];
         units:unit units:db;
         rdfs:comment "Level trim"
     ] , [

--- a/plugins-fixed/mod-mda-EPiano.lv2/EPiano.ttl
+++ b/plugins-fixed/mod-mda-EPiano.lv2/EPiano.ttl
@@ -11,23 +11,6 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
-#mda:
-#    a doap:Project ;
-#    lv2:symbol "mda" ;
-#    doap:name "MDA LV2" ;
-#    doap:shortdesc "An LV2 port of the MDA plugins." ;
-#    doap:homepage <http://drobilla.net/software/mda-lv2> ;
-#    doap:maintainer [
-#        foaf:name "MOD Team";
-#        foaf:homepage <http://moddevices.com>;
-#        foaf:mbox <mailto:devel@moddevices.com>;
-#    ] ;
-#    doap:developer [
-#        a foaf:Person ;
-#        foaf:name "Paul Kellett" ;
-#        foaf:mbox <mailto:paul@mda-vst.com>
-#    ] .
-
 mda:mainIn
     a pg:StereoGroup ,
         pg:InputGroup ;
@@ -75,20 +58,22 @@ Rhodes© Pianos are a trademark or trade name of another manufacturer and were u
         lv2:index 0 ;
         lv2:name "Envelope Decay" ;
         lv2:symbol "env_decay" ;
-        lv2:default 50.0 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 100.0;
-        units:unit units:pc
+        lv2:default 8.5 ;
+        lv2:minimum 3.0 ;
+        lv2:maximum 23.0;
+        lv2:portProperty epp:logarithmic;
+        units:unit units:seconds
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;
         lv2:index 1 ;
         lv2:name "Envelope Release" ;
         lv2:symbol "env_release" ;
-        lv2:default 50.0 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 100.0 ;
-        units:unit units:pc
+        lv2:default 0.12 ;
+        lv2:minimum 0.01 ;
+        lv2:maximum 1.4 ;
+        lv2:portProperty epp:logarithmic;
+        units:unit units:seconds
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;
@@ -125,9 +110,10 @@ Rhodes© Pianos are a trademark or trade name of another manufacturer and were u
         lv2:name "LFO Rate" ;
         lv2:portProperty  mod:tapTempo , mod:tempoRelatedDynamicScalePoints;
         lv2:symbol "lfo_rate" ;
-        lv2:default 23.285 ;
-        lv2:minimum 0.07 ;
-        lv2:maximum 36.97 ;
+        lv2:default 4.0 ;
+        lv2:minimum 0.05 ;
+        lv2:maximum 40.0 ;
+        lv2:portProperty epp:logarithmic;
         units:unit units:hz
     ] , [
         a lv2:InputPort ,

--- a/plugins-fixed/mod-mda-JX10.lv2/JX10.ttl
+++ b/plugins-fixed/mod-mda-JX10.lv2/JX10.ttl
@@ -9,23 +9,6 @@
 @prefix units: <http://lv2plug.in/ns/extensions/units#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
-#mda:
-#    a doap:Project ;
-#    lv2:symbol "mda" ;
-#    doap:name "MDA LV2" ;
-#    doap:shortdesc "An LV2 port of the MDA plugins." ;
-#    doap:homepage <http://drobilla.net/software/mda-lv2> ;
-#    doap:maintainer [
-#        foaf:name "MOD Team";
-#        foaf:homepage <http://moddevices.com>;
-#        foaf:mbox <mailto:devel@moddevices.com>;
-#    ] ;
-#    doap:developer [
-#        a foaf:Person ;
-#        foaf:name "Paul Kellett" ;
-#        foaf:mbox <mailto:paul@mda-vst.com>
-#    ] .
-
 mda:mainIn
     a pg:StereoGroup ,
         pg:InputGroup ;
@@ -96,7 +79,7 @@ Modeled by MDA
 		lv2:minimum 0.0 ;
 		lv2:maximum 1.0 ;
     mod:default 0.5 ;
-		units:unit units:semitone12TET ;
+		#units:unit units:semitone12TET ;
 		rdfs:comment "Tuning of second oscillator in semitones"
 	] , [
 		a lv2:InputPort ,
@@ -107,7 +90,7 @@ Modeled by MDA
 		lv2:default 0.25 ;
 		lv2:minimum 0.0 ;
 		lv2:maximum 1.0 ;
-		units:unit units:cent ;
+		#units:unit units:cent ;
 		rdfs:comment "Tuning of second oscillator in cents"
 	] , [
 		a lv2:InputPort ,
@@ -325,7 +308,7 @@ Modeled by MDA
 		lv2:default 0.5 ;
 		lv2:minimum 0.0 ;
 		lv2:maximum 1.0 ;
-		units:unit units:cent ;
+		#units:unit units:cent ;
 		rdfs:comment "Master tuning in cents"
 	] , [
 		a lv2:OutputPort ,

--- a/plugins-fixed/mod-mda-RePsycho.lv2/RePsycho.ttl
+++ b/plugins-fixed/mod-mda-RePsycho.lv2/RePsycho.ttl
@@ -83,7 +83,7 @@ Modeled by MDA
         lv2:name "Fine" ;
         lv2:symbol "fine" ;
         lv2:default 0.0 ;
-        lv2:minimum -99.0 ;
+        lv2:minimum -100.0 ;
         lv2:maximum 0.0 ;
         units:unit units:cent ;
         rdfs:comment "Fine tune (cents)"

--- a/plugins-fixed/mod-mda-ThruZero.lv2/ThruZero.ttl
+++ b/plugins-fixed/mod-mda-ThruZero.lv2/ThruZero.ttl
@@ -70,12 +70,13 @@ This plug simulates tape-flanging, where two copies of a signal cancel out compl
         lv2:symbol "rate" ;
         lv2:default 20.00 ;
         lv2:minimum 0.10 ;
-        lv2:maximum 93.34 ;
+        lv2:maximum 100 ;
+        lv2:portProperty epp:logarithmic;
         lv2:scalePoint [
             rdfs:label "-" ;
-            rdf:value 93.34
+            rdf:value 100
         ];
-        units:unit units:s ;
+        units:unit units:hz ;
 
         rdfs:comment "Modulation rate (sine wave) - set to minimum for static comb filtering"
     ] , [
@@ -86,7 +87,7 @@ This plug simulates tape-flanging, where two copies of a signal cancel out compl
         lv2:symbol "depth" ;
         lv2:default 20.0 ;
         lv2:minimum 0.0 ;
-        lv2:maximum 45.35 ;
+        lv2:maximum 42.00 ;
         units:unit units:ms ;
         rdfs:comment "Maximum modulation depth"
     ] , [

--- a/plugins-fixed/mod-mda-Vocoder.lv2/Vocoder.ttl
+++ b/plugins-fixed/mod-mda-Vocoder.lv2/Vocoder.ttl
@@ -9,23 +9,6 @@
 @prefix units: <http://lv2plug.in/ns/extensions/units#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
-#mda:
-#    a doap:Project ;
-#    lv2:symbol "mda" ;
-#    doap:name "MDA LV2" ;
-#    doap:shortdesc "An LV2 port of the MDA plugins." ;
-#    doap:homepage <http://drobilla.net/software/mda-lv2> ;
-#    doap:maintainer [
-#        foaf:name "MOD Team";
-#        foaf:homepage <http://moddevices.com>;
-#        foaf:mbox <mailto:devel@moddevices.com>;
-#    ] ;
-#    doap:developer [
-#        a foaf:Person ;
-#        foaf:name "Paul Kellett" ;
-#        foaf:mbox <mailto:paul@mda-vst.com>
-#    ] .
-
 mda:mainIn
     a pg:StereoGroup ,
         pg:InputGroup ;
@@ -92,7 +75,7 @@ Modeled by MDA
         lv2:symbol "output" ;
         lv2:default 0.0 ;
         lv2:minimum -20.0 ;
-        lv2:maximum 20.0 ;
+        lv2:maximum 0.0 ;
         units:unit units:db ;
 
         rdfs:comment "Level trim"
@@ -130,6 +113,7 @@ Modeled by MDA
         lv2:minimum 14.0 ;
         lv2:maximum 10000.0 ;
         units:unit units:ms ;
+        lv2:portProperty epp:logarithmic;
         lv2:scalePoint [
             rdf:value 14.0 ;
             rdfs:label "FREEZE" ;
@@ -152,7 +136,7 @@ Modeled by MDA
         a lv2:InputPort ,
             lv2:ControlPort ;
         lv2:index 6 ;
-        lv2:name "Mid Freq" ;
+        lv2:name "Mid Freq 400Hz" ;
         lv2:symbol "mid_freq" ;
         lv2:portProperty epp:logarithmic;
         lv2:default 1000.0 ;

--- a/plugins/mod-mda-Degrade.lv2/Degrade.ttl
+++ b/plugins/mod-mda-Degrade.lv2/Degrade.ttl
@@ -30,10 +30,10 @@ mda:Degrade
         lv2:index 0 ;
         lv2:name "Headroom" ;
         lv2:symbol "headroom" ;
-        lv2:default 0.8 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 1.0 ;
-#        units:unit units:db ;
+        lv2:default -6.0 ;
+        lv2:minimum -30.0 ;
+        lv2:maximum 0.0 ;
+        units:unit units:db ;
         rdfs:comment "Peak clipping threshold"
     ] , [
         a lv2:InputPort ,
@@ -41,15 +41,15 @@ mda:Degrade
         lv2:index 1 ;
         lv2:name "Quant" ;
         lv2:symbol "quant" ;
-#        lv2:portProperty lv2:integer ;
-        lv2:default 0.5 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 1.0 ;
-#        units:unit [
-#        rdfs:label   "bits" ;
-#        units:symbol "bit" ;
-#        units:render "%f bits"
-#        ] ;
+        lv2:portProperty lv2:integer ;
+        lv2:default 10 ;
+        lv2:minimum 4 ;
+        lv2:maximum 16 ;
+        units:unit [
+          rdfs:label   "bits" ;
+          units:symbol "bit" ;
+          units:render "%f bits"
+        ] ;
         rdfs:comment """Bit depth (typically 8 or below for "telephone" quality)"""
     ] , [
         a lv2:InputPort ,
@@ -57,65 +57,92 @@ mda:Degrade
         lv2:index 2 ;
         lv2:name "Rate" ;
         lv2:symbol "rate" ;
-#        lv2:portProperty lv2:integer ;
-#        lv2:portProperty epp:logarithmic ;
-        lv2:default 0.65 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 1.0 ;
+        lv2:portProperty lv2:integer ;
+        lv2:portProperty epp:logarithmic ;
+        lv2:default 48000 ;
+        lv2:minimum 4800 ;
+        lv2:maximum 48000 ;
         units:unit [
-        rdfs:label   "ssh" ;
-        units:symbol "s_sh" ;
-        units:render "%f S<>S&&H"
+          rdfs:label   "ssh" ;
+          units:symbol "s_sh" ;
+          units:render "%f Hz"
         ] ;
         rdfs:comment "Sample Rate (turn control to left or right for different sound characters)"
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;
         lv2:index 3 ;
-        lv2:name "Post Filter" ;
-        lv2:symbol "post_filt" ;
-#        lv2:portProperty lv2:integer ;
-#        lv2:portProperty epp:logarithmic ;
-        lv2:default 0.9 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 1.0 ;
-#        units:unit units:db ;
-        rdfs:comment "Low-pass filter to muffle the distortion produced by the previous two controls"
+        lv2:name "Integrator" ;
+        lv2:symbol "integrator_sr" ;
+        lv2:default 0 ;
+        lv2:minimum 0 ;
+        lv2:maximum 1 ;
+        lv2:portProperty lv2:enumeration , lv2:integer ;
+        lv2:scalePoint [
+            rdfs:label "Integrator Off" ;
+            rdf:value 0
+        ] , [
+            rdfs:label "Integrator On" ;
+            rdf:value 1
+        ]
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;
         lv2:index 4 ;
+        lv2:name "Post Filter" ;
+        lv2:symbol "post_filt" ;
+        lv2:portProperty lv2:integer ;
+        lv2:portProperty epp:logarithmic ;
+        lv2:default 15000 ;
+        lv2:minimum 200 ;
+        lv2:maximum 20000 ;
+        units:unit units:Hz ;
+        rdfs:comment "Low-pass filter to muffle the distortion produced by the previous two controls"
+    ] , [
+        a lv2:InputPort ,
+            lv2:ControlPort ;
+        lv2:index 5 ;
         lv2:name "Non-Lin" ;
         lv2:symbol "non_lin" ;
-#        lv2:portProperty lv2:integer ;
-        lv2:default 0.58 ;
+        lv2:default 0.16 ;
         lv2:minimum 0.0 ;
         lv2:maximum 1.0 ;
         units:unit [
-        rdfs:label   "oddeve" ;
-        units:symbol "oddeve" ;
-        units:render "%f Odd<>Eve"
+        rdfs:label   "nonlin" ;
+        units:symbol "nonlin" ;
         ] ;
         rdfs:comment """Additional harmonic distortion "thickening" (turn control to left or right for different sound characters)"""
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;
-        lv2:index 5 ;
+        lv2:index 6 ;
+        lv2:name "EvenOdd" ;
+        lv2:symbol "even_odd" ;
+        lv2:default 1 ;
+        lv2:minimum 0 ;
+        lv2:maximum 1 ;
+        lv2:portProperty lv2:enumeration , lv2:integer ;
+        lv2:scalePoint [
+            rdfs:label "Even" ;
+            rdf:value 0
+        ] , [
+            rdfs:label "Odd" ;
+            rdf:value 1
+        ]
+    ] , [
+        a lv2:InputPort ,
+            lv2:ControlPort ;
+        lv2:index 7 ;
         lv2:name "Output" ;
         lv2:symbol "output" ;
 #        lv2:portProperty lv2:integer ;
-        lv2:default 0.5 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 1.0 ;
-        units:unit [
-        rdfs:label   "oddeve" ;
-        units:symbol "oddeve" ;
-        units:render "%f Odd<>Eve"
-        ] ;
+        lv2:default 0.0 ;
+        lv2:minimum -20.0 ;
+        lv2:maximum 20.0 ;
     ] , [
         a lv2:InputPort ,
             lv2:AudioPort ;
-        lv2:index 6 ;
+        lv2:index 8 ;
         lv2:symbol "left_in" ;
         lv2:name "Left In" ;
         lv2:designation pg:left ;
@@ -123,7 +150,7 @@ mda:Degrade
     ] , [
         a lv2:InputPort ,
             lv2:AudioPort ;
-        lv2:index 7 ;
+        lv2:index 9 ;
         lv2:symbol "right_in" ;
         lv2:name "Right In" ;
         lv2:designation pg:right ;
@@ -131,7 +158,7 @@ mda:Degrade
     ] , [
         a lv2:OutputPort ,
             lv2:AudioPort ;
-        lv2:index 8 ;
+        lv2:index 10 ;
         lv2:symbol "left_out" ;
         lv2:name "Left Out" ;
         lv2:designation pg:left ;
@@ -139,7 +166,7 @@ mda:Degrade
     ] , [
         a lv2:OutputPort ,
             lv2:AudioPort ;
-        lv2:index 9 ;
+        lv2:index 11 ;
         lv2:symbol "right_out" ;
         lv2:name "Right Out" ;
         lv2:designation pg:right ;

--- a/plugins/mod-mda-Delay.lv2/Delay.ttl
+++ b/plugins/mod-mda-Delay.lv2/Delay.ttl
@@ -30,10 +30,10 @@ mda:Delay
         lv2:index 0 ;
         lv2:name "L Delay" ;
         lv2:symbol "l_delay" ;
-        lv2:default 0.5 ;
+        lv2:default 250 ;
         lv2:minimum 0.0 ;
-        lv2:maximum 1.0 ;
-#        units:unit units:ms ;
+        lv2:maximum 330.0 ;
+        units:unit units:ms ;
         rdfs:comment "Left channel delay time";
 
     ] , [
@@ -42,68 +42,85 @@ mda:Delay
         lv2:index 1 ;
         lv2:name "R/L Delay" ;
         lv2:symbol "rl_delay" ;
-        lv2:default 0.27 ;
+        lv2:default 1.0 ;
         lv2:minimum 0.0 ;
-        lv2:maximum 1.0 ;
+        lv2:maximum 2.0 ;
         rdfs:comment "Right channel delay as a percentage of left channel delay - variable to left, fixed ratios to right";
 
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;
         lv2:index 2 ;
+        lv2:name "R Delay Fixed Ratios" ;
+        lv2:symbol "rl_fixed_ratios" ;
+        lv2:default 0 ;
+        lv2:minimum 0 ;
+        lv2:maximum 1 ;
+        lv2:portProperty lv2:enumeration , lv2:integer ;
+        lv2:scalePoint [
+            rdfs:label "Free" ;
+            rdf:value 0
+        ] , [
+            rdfs:label "Fixed" ;
+            rdf:value 1
+        ]
+    ] , [
+        a lv2:InputPort ,
+            lv2:ControlPort ;
+        lv2:index 3 ;
         lv2:name "Feedback" ;
         lv2:symbol "feedback" ;
-        lv2:default 0.7 ;
+        lv2:default 70.0 ;
         lv2:minimum 0.0 ;
-        lv2:maximum 1.0 ;
-#        units:unit units:pc ;
+        lv2:maximum 100.0 ;
+        units:unit units:pc ;
         rdfs:comment "Feedback (sum of left and right outputs)";
 
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;
-        lv2:index 3 ;
-        lv2:name "Fb Tone" ;
+        lv2:index 4 ;
+        lv2:name "Fb Tone\nLo<>Hi" ;
         lv2:symbol "fb_tone" ;
-        lv2:default 0.5 ;
-        lv2:minimum 0.0 ;
+        lv2:default 0.0 ;
+        lv2:minimum -1.0 ;
         lv2:maximum 1.0 ;
-        units:unit [
-        rdfs:label   "lohi" ;
-        units:symbol "lohi" ;
-        units:render "%f Lo<>Hi"
-        ] ;
+        #units:unit [
+        #rdfs:label   "lohi" ;
+        #units:symbol "lohi" ;
+        #units:render "%f Lo<>Hi"
+        #] ;
         rdfs:comment "Feedback filtering - low-pass to left, high-pass to right";
 
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;
-        lv2:index 4 ;
+        lv2:index 5 ;
         lv2:name "FX Mix" ;
         lv2:symbol "fx_mix" ;
-        lv2:default 0.33 ;
+        lv2:default 33.0 ;
         lv2:minimum 0.0 ;
-        lv2:maximum 1.0 ;
+        lv2:maximum 100.0 ;
         rdfs:comment "Wet / dry mix";
-#        units:unit units:pc ;
+        units:unit units:pc ;
 
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;
-        lv2:index 5 ;
+        lv2:index 6 ;
         lv2:name "Output" ;
         lv2:symbol "output" ;
-        lv2:default 0.5 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 1.0 ;
-#        units:unit units:db ;
+        lv2:default 0.0 ;
+        lv2:minimum -12.0 ;
+        lv2:maximum 6.0 ;
+        units:unit units:db ;
         lv2:scalePoint [rdfs:label "OFF" ;rdf:value 0.0];
         rdfs:comment "Level trim";
 
     ] , [
         a lv2:InputPort ,
             lv2:AudioPort ;
-        lv2:index 6 ;
+        lv2:index 7 ;
         lv2:symbol "left_in" ;
         lv2:name "Left In" ;
         lv2:designation pg:left ;
@@ -111,7 +128,7 @@ mda:Delay
     ] , [
         a lv2:InputPort ,
             lv2:AudioPort ;
-        lv2:index 7 ;
+        lv2:index 8 ;
         lv2:symbol "right_in" ;
         lv2:name "Right In" ;
         lv2:designation pg:right ;
@@ -119,7 +136,7 @@ mda:Delay
     ] , [
         a lv2:OutputPort ,
             lv2:AudioPort ;
-        lv2:index 8 ;
+        lv2:index 9 ;
         lv2:symbol "left_out" ;
         lv2:name "Left Out" ;
         lv2:designation pg:left ;
@@ -127,7 +144,7 @@ mda:Delay
     ] , [
         a lv2:OutputPort ,
             lv2:AudioPort ;
-        lv2:index 9 ;
+        lv2:index 10 ;
         lv2:symbol "right_out" ;
         lv2:name "Right Out" ;
         lv2:designation pg:right ;


### PR DESCRIPTION
many lv2 plugins had incorrect interpolation or incorrect labels for plugins parameters, these should be fixed for the most part.