### PR TITLE
Update gxtubetremelo.ttl

### DIFF
--- a/plugins/gxtubetremelo.lv2/gxtubetremelo.ttl
+++ b/plugins/gxtubetremelo.lv2/gxtubetremelo.ttl
@@ -24,6 +24,9 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix guiext: <http://lv2plug.in/ns/extensions/ui#>.
+@prefix units: <http://lv2plug.in/ns/extensions/units#> .
+@prefix mod: <http://moddevices.com/ns/mod#>.
+@prefix time: <http://lv2plug.in/ns/ext/time#>.
 
 <http://guitarix.sourceforge.net#me>
 	a foaf:Person ;
@@ -89,6 +92,8 @@ http://transmogrifox.webs.com/vactrol.m
         lv2:default 0.1 ;
         lv2:minimum 0.1 ;
         lv2:maximum 14.0 ;
+	units:unit units:hz ;
+        lv2:portProperty  mod:tempoRelatedDynamicScalePoints;    
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;


### PR DESCRIPTION
possibility to control the Speed with the host/mod tempo (Translate values to musical tempo)

by the way in the HMI, I think it would be better to show the Tempo and also the ms in the line below (and use the first line for the up-down chars)